### PR TITLE
feat: use APP_HOSTNAME for setting a parent of the Twitch player container

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_APP_HOSTNAME=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.tsbuildinfo
+.env
 .vercel
 /.next/
 /build

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 
+const APP_HOSTNAME =
+  process.env.NEXT_PUBLIC_APP_HOSTNAME ?? process.env.VERCEL_URL;
+
 export default function Home() {
   return (
     <>
@@ -17,21 +20,10 @@ export default function Home() {
           </div>
         </div>
 
-        {/* This commented code is for showing the twitch embed on local host, the uncommented should work when deployed to vercel ( not entirely sure but after the first push 
-          we will know if it works for sure) */}
-        {/* <div id="Twitch player">
+        <div id="twitch-player">
           <iframe
             className="container text-center items-center h-[32rem]"
-            src="https://player.twitch.tv/?channel=nuilzero&parent=localhost"
-            frameBorder="0"
-            allowFullScreen={true}
-            scrolling="no"
-          ></iframe>
-        </div> */}
-        <div id="Twitch player">
-          <iframe
-            className="container text-center items-center h-[32rem]"
-            src="https://player.twitch.tv/?channel=nuilzero&parent=https://nuilzero.tv/"
+            src={`https://player.twitch.tv/?channel=nuilzero&parent=${APP_HOSTNAME}`}
             frameBorder="0"
             allowFullScreen={true}
             scrolling="no"


### PR DESCRIPTION
To get this working locally, you'll need to copy `.env.sample` over to `.env`.