### PR TITLE
fix: combine redirct config blocks and route /twitch

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,18 +5,14 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/nuilzeroTwitch",
-        destination: "https://twitch.tv/nuilzero",
+        source: "/github",
+        destination: "https://github.com/FalseMann/nuilzero",
         permanent: false,
         basePath: false,
       },
-    ];
-  },
-  async redirects() {
-    return [
       {
-        source: "/github",
-        destination: "https://github.com/FalseMann/nuilzero",
+        source: "/twitch",
+        destination: "https://twitch.tv/nuilzero",
         permanent: false,
         basePath: false,
       },


### PR DESCRIPTION
This change fixes a bug in the redirect configuration and points `/twitch` to nuil's Twitch page.